### PR TITLE
handle destructuring for null body

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,8 @@ async function scrollPageToBottom(page, scrollStep = 250, scrollDelay = 100) {
   const lastPosition = await page.evaluate(
     async (step, delay) => {
       const getScrollHeight = (element) => {
+        if (!element) return 0
+
         const { scrollHeight, offsetHeight, clientHeight } = element
         return Math.max(scrollHeight, offsetHeight, clientHeight)
       }


### PR DESCRIPTION
It might happen that the body is null. When so, there is an infinite loop not handled in which the page remains open.

For me, it is randomly happening for amazon.it.

These are the steps I do

```
await page.goto(url)
await page.waitForNavigation({ waitUntil: 'networkidle2', timeout: 10000 })

await scrollPageToBottom(page)
await page.waitForNavigation({ waitUntil: 'networkidle2', timeout: 10000 })
```